### PR TITLE
Fix "Import project..." wizard

### DIFF
--- a/bundles/org.eclipse.team.cvs.ui/src/org/eclipse/team/internal/ccvs/ui/CVSUIPlugin.java
+++ b/bundles/org.eclipse.team.cvs.ui/src/org/eclipse/team/internal/ccvs/ui/CVSUIPlugin.java
@@ -255,6 +255,9 @@ public class CVSUIPlugin extends AbstractUIPlugin {
 	 * @return the plugin instance
 	 */
 	public static CVSUIPlugin getPlugin() {
+		if (plugin == null) {
+			plugin = new CVSUIPlugin();
+		}
 		return plugin;
 	}
 	


### PR DESCRIPTION
When calling getPlugin() method, it ensures that the class had been initialized. 

Fix working in Eclipse IDE 2023-09